### PR TITLE
Log mappings + reorder them to fix issues

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -15,5 +15,9 @@
     "spellright.documentTypes": [
         "markdown",
         "plaintext"
-    ]
+    ],
+    "[python]": {
+        "editor.defaultFormatter": "ms-python.black-formatter"
+    },
+    "python.formatting.provider": "none"
 }

--- a/pythonFiles/launch.py
+++ b/pythonFiles/launch.py
@@ -8,7 +8,7 @@ include_dir = Path(__file__).parent / "include"
 sys.path.append(str(include_dir))
 
 import blender_vscode
-print(json.loads(os.environ['ADDONS_TO_LOAD']))
+print("ADDONS_TO_LOAD", json.loads(os.environ['ADDONS_TO_LOAD']))
 
 try:
     blender_vscode.startup(

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -13,7 +13,28 @@ import {
     COMMAND_openScriptsFolder
 } from './scripts';
 
+let outputChannel: vscode.OutputChannel;
+
+/**
+ * Prints the given content on the output channel.
+ *
+ * @param content The content to be printed.
+ * @param reveal Whether the output channel should be revealed.
+ */
+export const printChannelOutput = (content: string, reveal = false): void => {
+    outputChannel.appendLine(content);
+    if (reveal) {
+        outputChannel.show(true);
+    }
+};
+
+/* Registration
+ *********************************************/
+
 export function activate(context: vscode.ExtensionContext) {
+    outputChannel = vscode.window.createOutputChannel("Blender debugpy");
+    printChannelOutput("activated...", true);
+
     let commands: [string, () => Promise<void>][] = [
         ['blender.start', COMMAND_start],
         ['blender.stop', COMMAND_stop],


### PR DESCRIPTION
My fix to the issues related to https://github.com/JacquesLucke/blender_vscode/issues/140

Logs the mapping json to a vscode logging output
Reorders the mappings to fix breakpoints being triggered in a read-only state instead of the source file
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

---
- New Feature: Added a new function `printChannelOutput` in `src/extension.ts` that allows for printing content to a dedicated output channel. This enhances the debugging experience by providing a separate space for debug-related logs.
- Refactor: Updated `src/python_debugging.ts` to include addon path mappings, optional script folders, and workspace folder mappings in the `getPythonPathMappings` function. This change improves the flexibility of Python path configuration.
- Chore: Modified `.vscode/settings.json` to set a default formatter for Python files and disable automatic formatting. This ensures consistent code style across the project.
- Style: Adjusted log output in `pythonFiles/launch.py` for better clarity on loaded addons.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->